### PR TITLE
Migration rails 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ traductions des termes utilisés par Rails. Il traduit également les 'new' et
 Attention à utiliser la bonne version du plugin en fonction de la version de
 Rails :
 
+- FrenchRails 0.6 est compatible avec Rails 7
 - FrenchRails 0.5 est compatible avec Rails 6
 - FrenchRails 0.4 est compatible avec Rails 5
 - FrenchRails 0.3 est compatible avec Rails 4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ traductions des termes utilisés par Rails. Il traduit également les 'new' et
 Attention à utiliser la bonne version du plugin en fonction de la version de
 Rails :
 
+- FrenchRails 0.5 est compatible avec Rails 6
 - FrenchRails 0.4 est compatible avec Rails 5
 - FrenchRails 0.3 est compatible avec Rails 4
 - FrenchRails 0.2 est compatible avec Rails 3

--- a/french_rails.gemspec
+++ b/french_rails.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.md)
   s.files            = Dir["MIT-LICENSE", "README.md", "Gemfile", "lib/**/*.rb", "locales/*.yml"]
   s.require_paths    = ["lib"]
-  s.add_dependency "rails", "~>6.0"
+  s.add_dependency "rails", "~>7.0"
 end

--- a/french_rails.gemspec
+++ b/french_rails.gemspec
@@ -1,4 +1,4 @@
-require 'french_rails/version'
+require './lib/french_rails/version'
 
 Gem::Specification.new do |s|
   s.name             = "french_rails"
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.md)
   s.files            = Dir["MIT-LICENSE", "README.md", "Gemfile", "lib/**/*.rb", "locales/*.yml"]
   s.require_paths    = ["lib"]
-  s.add_dependency "rails", "~>5.0"
+  s.add_dependency "rails", "~>6.0"
 end

--- a/lib/french_rails/version.rb
+++ b/lib/french_rails/version.rb
@@ -1,3 +1,3 @@
 module FrenchRails
-  Version = "0.5.0"
+  Version = "0.6.0"
 end

--- a/lib/french_rails/version.rb
+++ b/lib/french_rails/version.rb
@@ -1,3 +1,3 @@
 module FrenchRails
-  Version = "0.4.3"
+  Version = "0.5.0"
 end


### PR DESCRIPTION
Afin de permettre l'évolution de linuxfr vers rails 6, puis 7, changement de dépendances.